### PR TITLE
Fix/assign datetime with utc timezone

### DIFF
--- a/checkups/app/storage.py
+++ b/checkups/app/storage.py
@@ -2,6 +2,7 @@ from sqlalchemy.orm import Session
 from typing import List
 from common.schemas.checkup import CheckupIn
 from common.models import Checkup
+from common.utils import get_current_time
 
 
 def get_checkup(db: Session, checkup_id: int) -> Checkup:
@@ -18,9 +19,12 @@ def get_checkups_by_doctor(db: Session, doctor_id: int) -> List[Checkup]:
 
 def create_checkup(db: Session, checkup: CheckupIn) -> Checkup:
     new_checkup = Checkup(**checkup.dict())
+    new_checkup.date = get_current_time()
 
     db.add(new_checkup)
+
     db.commit()
+    db.refresh(new_checkup)
 
     return new_checkup
 

--- a/common/models.py
+++ b/common/models.py
@@ -38,7 +38,7 @@ class Checkup(Base):
     doctor_id = Column(Integer, ForeignKey("doctor.id"))
     patient_id = Column(Integer, ForeignKey("patient.id"))
     data = Column(JSON)
-    date = Column(DateTime, default=datetime.datetime.now())
+    date = Column(DateTime(timezone=True))
     patient = relationship(
         "Patient", back_populates="checkups", lazy="joined", join_depth=2)
     doctor = relationship(
@@ -86,8 +86,8 @@ class Hospital(Base):
     name = Column(String)
     schedule = Column(String(250))
     location_id = Column(Integer, ForeignKey("location.id"))
-    created_at = Column(DateTime, default=datetime.datetime.now())
-    updated_at = Column(DateTime)
+    created_at = Column(DateTime(timezone=True))
+    updated_at = Column(DateTime(timezone=True))
 
     location = relationship(
         "Location",
@@ -159,8 +159,8 @@ class Template(Base):
     numeric_fields = Column(Integer)
     alphanumeric_fields = Column(Integer)
     file_upload_fields = Column(Integer)
-    created_at = Column(DateTime, default=datetime.datetime.now())
-    updated_at = Column(DateTime)
+    created_at = Column(DateTime(timezone=True))
+    updated_at = Column(DateTime(timezone=True))
 
 
 class UserRole(str, enum.Enum):
@@ -202,8 +202,8 @@ class User(Base):
     email = Column(String, unique=True)
     document_number = Column(String(11))
     date_of_birth = Column(Date)
-    created_at = Column(DateTime, server_default=func.now())
-    updated_at = Column(DateTime, onupdate=func.now())
+    created_at = Column(DateTime(timezone=True))
+    updated_at = Column(DateTime(timezone=True))
 
     patient = relationship("Patient", back_populates="user", uselist=False)
     doctor = relationship("Doctor", back_populates="user", uselist=False)
@@ -216,7 +216,7 @@ SessionLocal = sessionmaker(
     autocommit=False, autoflush=False, bind=engine)
 
 
-@compiles(DropTable, "postgresql")
+@ compiles(DropTable, "postgresql")
 def _compile_drop_table(element, compiler, **kwargs):
     return compiler.visit_drop_table(element) + " CASCADE"
 

--- a/common/requirements.txt
+++ b/common/requirements.txt
@@ -6,6 +6,7 @@ pathspec==0.9.0
 platformdirs==2.3.0
 psycopg2-binary==2.9.1
 pydantic==1.8.2
+pytz==2021.3
 regex==2021.8.28
 SQLAlchemy==1.4.23
 sqlalchemy2-stubs==0.0.2a15

--- a/common/utils.py
+++ b/common/utils.py
@@ -1,0 +1,10 @@
+from datetime import datetime
+import pytz
+
+DR_TIMEZONE_NAME = "America/Santo_Domingo"
+
+DR_TIMEZONE = pytz.timezone(DR_TIMEZONE_NAME)
+
+
+def get_current_time() -> datetime:
+    return datetime.now(DR_TIMEZONE)

--- a/common/utils.py
+++ b/common/utils.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+import datetime
 import pytz
 
 DR_TIMEZONE_NAME = "America/Santo_Domingo"
@@ -6,5 +6,5 @@ DR_TIMEZONE_NAME = "America/Santo_Domingo"
 DR_TIMEZONE = pytz.timezone(DR_TIMEZONE_NAME)
 
 
-def get_current_time() -> datetime:
-    return datetime.now(DR_TIMEZONE)
+def get_current_time() -> datetime.datetime:
+    return datetime.datetime.now(datetime.timezone.utc)

--- a/users/app/storage.py
+++ b/users/app/storage.py
@@ -22,10 +22,12 @@ def create_patient(db: Session, user: UserIn) -> User:
 
     try:
         db_user = User(
-            **user.dict(exclude={"patient"}), password=hashed_password)
-        db_patient = Patient(**user.patient.dict(), user=db_user)
+            **user.dict(exclude={"patient"}), password=hashed_password
+        )
 
-        db_patient.created_at = get_current_time()
+        db_user.created_at = get_current_time()
+
+        db_patient = Patient(**user.patient.dict(), user=db_user)
 
         db.add(db_user)
         db.add(db_patient)
@@ -46,10 +48,12 @@ def create_admin(db: Session, user: UserIn) -> User:
 
     try:
         db_user = User(
-            **user.dict(exclude={"admin"}), password=hashed_password)
-        db_admin = Admin(**user.admin.dict(), user=db_user)
+            **user.dict(exclude={"admin"}), password=hashed_password
+        )
 
-        db_admin.created_at = get_current_time()
+        db_user.created_at = get_current_time()
+
+        db_admin = Admin(**user.admin.dict(), user=db_user)
 
         db.add(db_user)
         db.add(db_admin)
@@ -70,7 +74,11 @@ def create_doctor(db: Session, user: UserIn) -> User:
 
     try:
         db_user = User(
-            **user.dict(exclude={"doctor"}), password=hashed_password)
+            **user.dict(exclude={"doctor"}), password=hashed_password
+        )
+
+        db_user.created_at = get_current_time()
+
         db_doctor = Doctor(
             **user.doctor.dict(exclude={"specialty_ids"}), user=db_user)
 
@@ -78,7 +86,6 @@ def create_doctor(db: Session, user: UserIn) -> User:
             Specialty.id.in_(user.doctor.specialty_ids)).all()
 
         db_doctor.specialties = specialties
-        db_doctor.created_at = get_current_time()
 
         db.add(db_user)
         db.add(db_doctor)

--- a/users/app/storage.py
+++ b/users/app/storage.py
@@ -6,6 +6,7 @@ from dependencies import Session
 from common.schemas.user import User, UserIn, UserRole, UserUpdate
 from common.models import Base, Patient, User, Admin, Doctor, Specialty
 from utils import generate_password
+from common.utils import get_current_time
 
 ALLOWED_USER_UPDATES = ["name", "last_name",
                         "date_of_birth", "document_number"]
@@ -23,6 +24,8 @@ def create_patient(db: Session, user: UserIn) -> User:
         db_user = User(
             **user.dict(exclude={"patient"}), password=hashed_password)
         db_patient = Patient(**user.patient.dict(), user=db_user)
+
+        db_patient.created_at = get_current_time()
 
         db.add(db_user)
         db.add(db_patient)
@@ -45,6 +48,8 @@ def create_admin(db: Session, user: UserIn) -> User:
         db_user = User(
             **user.dict(exclude={"admin"}), password=hashed_password)
         db_admin = Admin(**user.admin.dict(), user=db_user)
+
+        db_admin.created_at = get_current_time()
 
         db.add(db_user)
         db.add(db_admin)
@@ -73,6 +78,7 @@ def create_doctor(db: Session, user: UserIn) -> User:
             Specialty.id.in_(user.doctor.specialty_ids)).all()
 
         db_doctor.specialties = specialties
+        db_doctor.created_at = get_current_time()
 
         db.add(db_user)
         db.add(db_doctor)
@@ -141,7 +147,7 @@ def update_user(db: Session, user_id: int, updated_user: UserUpdate) -> User:
                 if do_key_and_value_exist(key, value) and key in ALLOWED_DOCTOR_UPDATES:
                     setattr(user.doctor, key, value)
 
-        user.updated_at = datetime.datetime.now()
+        user.updated_at = get_current_time()
 
         db.commit()
         db.refresh(user)

--- a/users/app/tests/test_db.py
+++ b/users/app/tests/test_db.py
@@ -36,6 +36,7 @@ def test_db():
         email="test@gmail.com",
         document_number="12345654321",
         date_of_birth=datetime.datetime.strptime("01-20-2000", "%m-%d-%Y"),
+        created_at=datetime.datetime.now(datetime.timezone.utc)
     )
 
     patient = Patient(user=patient_user, blood_type="a_plus")

--- a/utilities/app/storage/hospital.py
+++ b/utilities/app/storage/hospital.py
@@ -1,9 +1,9 @@
 import traceback
-import datetime
 from typing import List
 from common.schemas.hospital import Hospital, HospitalIn, HospitalUpdate
 from common.schemas.location import Province
 from common.models import Hospital, Location
+from common.utils import get_current_time
 from dependencies import Session
 
 
@@ -22,8 +22,12 @@ def create_hospital(db: Session, hospital: HospitalIn) -> Hospital:
             raise ValueError("Invalid province")
 
         db_location = Location(**hospital.location.dict())
+
         db_hospital = Hospital(
-            **hospital.dict(exclude={"location"}), location=db_location)
+            **hospital.dict(exclude={"location"}),
+            location=db_location
+        )
+        db_hospital.created_at = get_current_time()
 
         db.add(db_location)
         db.add(db_hospital)
@@ -76,7 +80,7 @@ def update_hospital(db: Session, hospital_id: int, updated_hospital: HospitalUpd
 
                 hospital.location.province = updated_hospital.location.province
 
-        hospital.updated_at = datetime.datetime.now()
+        hospital.updated_at = get_current_time()
 
         db.commit()
         db.refresh(hospital)

--- a/utilities/app/storage/specialty.py
+++ b/utilities/app/storage/specialty.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 from sqlalchemy.sql.elements import and_
 
 from common.schemas.specialty import Specialty, SpecialtyIn, SpecialtyUpdate
-from common.models import Specialty, Hospital
+from common.models import Specialty
 from dependencies import Session
 
 

--- a/utilities/app/storage/templates.py
+++ b/utilities/app/storage/templates.py
@@ -1,11 +1,11 @@
 import json
 import traceback
-import datetime
 
 from sqlalchemy.sql.elements import and_
 
 from common.schemas.template import Template, TemplateIn, TemplateUpdate
 from common.models import Template
+from common.utils import get_current_time
 from dependencies import Session
 
 VALID_HEADER_TYPE = {
@@ -22,6 +22,7 @@ def create_template(db: Session, template: TemplateIn) -> Template:
 
     try:
         db_template = Template(**template.dict())
+        db_template.created_at = get_current_time()
 
         db.add(db_template)
 
@@ -72,8 +73,9 @@ def update_template(db: Session, template_id: int, updated_template: TemplateUpd
 
             template.numeric_fields = numeric_fields
             template.alphanumeric_fields = alphanumeric_fields
+            template.headers = updated_template.headers
 
-        template.updated_at = datetime.datetime.now()
+        template.updated_at = get_current_time()
 
         db.commit()
         db.refresh(template)

--- a/utilities/app/tests/test_hospital_router.py
+++ b/utilities/app/tests/test_hospital_router.py
@@ -21,7 +21,6 @@ def test_create_hospital(test_db):
     }
 
     response = client.post("/hospitals", json=payload)
-    data = response.json()
 
     assert response.status_code == status.HTTP_201_CREATED
 
@@ -91,6 +90,7 @@ def test_update_certain_hospital_fields(test_db):
     assert response.status_code == status.HTTP_200_OK
     assert data["name"] == "Updated hospital name"
     assert data["location"]["province"] == "samana"
+    assert data["updated_at"] is not None
 
 
 def delete_hospital(test_db):

--- a/utilities/app/tests/test_templates_router.py
+++ b/utilities/app/tests/test_templates_router.py
@@ -68,8 +68,10 @@ def test_update_template(test_db):
 
     assert response.status_code == status.HTTP_200_OK
     assert data["title"] == "Updated cardiac conditions"
+    assert data["headers"] == "{\"name\":\"string\",\"last_name\":\"string\"}"
     assert data["numeric_fields"] == 0
     assert data["alphanumeric_fields"] == 2
+    assert data["updated_at"] is not None
 
 
 def test_delete_template(test_db):


### PR DESCRIPTION
## Issue
fixes #11 
fixes #23 

## Tasks
- [x] Create `common/utils.py` to return the current datetime with a timezone
- [x] Update `users`, `utilities` and `checkups` containers to assign datetime with timezone
- [x] Update models with datatype `Datetime` to use timezones
- [x] Fix bug where template headers were not being updated during `PUT` method