### PR TITLE
Add "specialties" attribute to "Doctor" schema

### DIFF
--- a/common/schemas/doctor.py
+++ b/common/schemas/doctor.py
@@ -1,6 +1,8 @@
 from typing import Optional, List
 from pydantic import BaseModel
 
+from .specialty import Specialty
+
 
 class DoctorBase(BaseModel):
     hospital_id: int
@@ -18,6 +20,7 @@ class DoctorUpdate(BaseModel):
 
 class Doctor(DoctorBase):
     id: int
+    specialties: List[Specialty]
 
     class Config:
         orm_mode = True

--- a/users/app/tests/test_db.py
+++ b/users/app/tests/test_db.py
@@ -81,8 +81,8 @@ def test_db():
     )
 
     specialties = [
-        Specialty(name="pediatrician"),
-        Specialty(name="general")
+        Specialty(name="pediatrician", hospital_id=1),
+        Specialty(name="general", hospital_id=1)
     ]
 
     db.add(patient_user)

--- a/users/app/tests/test_main.py
+++ b/users/app/tests/test_main.py
@@ -45,8 +45,12 @@ def test_create_doctor(test_db):
     }
 
     response = client.post("/users", json=payload)
+    data: dict = response.json()
 
     assert response.status_code == status.HTTP_201_CREATED
+    assert data["doctor"] is not None
+    assert data["doctor"]["specialties"] is not None
+    assert len(data["doctor"]["specialties"]) == 2
 
 
 def test_create_admin(test_db):


### PR DESCRIPTION
## Issue
Fixes #22 

## Tasks
- [x] Add `specialties` attribute to "Doctor" schema
- [x] Modify `test_create_doctor` test to check for `specialties` array 

### Example of updated `User` JSON
```javascript
    {
        "user_role": "doctor",
        "document_type": "national_id",
        "name": "Alejandro2",
        "last_name": "del Toro",
        "email": "alejandro7@gmail.com",
        "document_number": "11111111111",
        "date_of_birth": "2000-06-27",
        "created_at": "2021-11-13T20:16:19.914899+00:00",
        "id": 6,
        "doctor": {
            "hospital_id": 1,
            "schedule": "test",
            "id": 2,
            "specialties": [
                {
                    "name": "Cardiología",
                    "hospital_id": 1,
                    "id": 1
                }
            ]
        }
    }
```